### PR TITLE
Don't complain about a nonexistent configuration file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,6 @@ func checkPermissions(f *os.File) {
 func Read() Config {
 	f, err := os.Open(gitlabCLIConf())
 	if err != nil {
-		fmt.Printf("WARNING: Error opening configuration file: %s\n\n", err)
 		return &defaultConfig
 	}
 	defer f.Close()


### PR DESCRIPTION
This warning is probably not needed if one can use the command without that file.

It is especially annoying as it's printed when one uses `gitlab-cli` without any command or `gitlab-cli --help`:

    $ gitlab-cli --help
    WARNING: Error opening configuration file: open /home/baptiste/.gitlab-cli.json: no such file or directory

    Usage:
      gitlab-cli [command]
    ...

Ideally, this file should be loaded on-demand by the commands that need it but with I don’t know how to do that without significant changes.

Feel free to ignore this PR if you think this is not a relevant change.