### PR TITLE
Rename the command from 'gitlab-cli' to 'gitlab'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,4 @@ jobs:
             env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             with:
-                args: 'build/gitlab-cli_*'
+                args: 'build/gitlab_*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/gitlab-cli
-/gitlab-cli_v*
+/gitlab
+/gitlab_v*
 cover.out
 /build

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ os = $(word 1, $@)
 CURRENT_DIR=$(shell pwd)
 BUILD_DIR=build
 PKG_DIR=/gitlab-cli_$(GOOS)
-BINARY_NAME=gitlab-cli
+BINARY_NAME=gitlab
 SRCS := $(shell find . -type f -name '*.go' -not -path './vendor/*')
 
 .PHONY: $(PLATFORMS)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or grab the binary of the [most current
 release](https://github.com/makkes/gitlab-cli/releases).
 
 All commands of gitlab-cli currently require that you are authenticated. To do
-so you issue `gitlab-cli login YOUR_TOKEN`. You obtain a personal access token
+so you issue `gitlab login YOUR_TOKEN`. You obtain a personal access token
 at https://gitlab.com/profile/personal_access_tokens. To make use of all of
 gitlab-cli's features you need to grant api, read_user, read_repository and
 read_registry scopes.
@@ -43,7 +43,7 @@ You can get your Bash to complete GitLab CLI commands very easily: Just type the
 following line in your shell:
 
 ```sh
-. <(gitlab-cli completion)
+. <(gitlab completion)
 ```
 
 To have completion set up for you automatically just copy and paste the line

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -12,12 +12,12 @@ func NewCommand(rootCmd *cobra.Command) *cobra.Command {
 		Short: "Generates bash completion scripts",
 		Long: `To load completions in the current shell run
 
-. <(gitlab-cli completion)
+. <(gitlab completion)
 		
 To configure your bash shell to load completions for each session add the
 following line to your ~/.bashrc or ~/.profile:
 
-. <(gitlab-cli completion)
+. <(gitlab completion)
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			rootCmd.GenBashCompletion(os.Stdout)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:          "gitlab-cli",
+	Use:          "gitlab",
 	SilenceUsage: true,
 }
 

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -15,7 +15,7 @@ func NewCommand(client api.Client, cfg config.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := cfg.Get("url")
 			if url == "" {
-				return fmt.Errorf("GitLab CLI is not configured, yet. Run »gitlab-cli login« first")
+				return fmt.Errorf("GitLab CLI is not configured, yet. Run »gitlab login« first")
 			}
 			fmt.Printf("Logged in at %s as %s\n", url, cfg.Get("user"))
 			return nil


### PR DESCRIPTION
closes #25.