### PR TITLE
Add --page parameter to projects and issues commands

### DIFF
--- a/cmd/issues/issues.go
+++ b/cmd/issues/issues.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -12,14 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func issuesCommand(args []string, client api.Client, all bool, out io.Writer) error {
+func issuesCommand(args []string, client api.Client, all bool, page int, out io.Writer) error {
 	project, err := client.FindProject(args[0])
 	if err != nil {
 		return err
 	}
-	path := "/projects/" + strconv.Itoa(project.ID) + "/issues"
+	path := "/projects/" + strconv.Itoa(project.ID) + fmt.Sprintf("/issues?page=%d", page)
 	if !all {
-		path += "?state=opened"
+		path += "&state=opened"
 	}
 	resp, _, err := client.Get(path)
 	if err != nil {
@@ -38,15 +39,17 @@ func issuesCommand(args []string, client api.Client, all bool, out io.Writer) er
 
 func NewCommand(client api.Client) *cobra.Command {
 	var all *bool
+	var page *int
 	cmd := &cobra.Command{
 		Use:   "issues PROJECT",
 		Short: "List issues in a project",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return issuesCommand(args, client, *all, os.Stdout)
+			return issuesCommand(args, client, *all, *page, os.Stdout)
 		},
 	}
 
 	all = cmd.Flags().BoolP("all", "a", false, "Show all issues (default shows just open)")
+	page = cmd.Flags().Int("page", 1, "Page of results to display")
 	return cmd
 }

--- a/cmd/projects/projects.go
+++ b/cmd/projects/projects.go
@@ -14,8 +14,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func projectsCommand(client api.Client, cfg config.Config, quiet bool, format string, out io.Writer) error {
-	resp, status, err := client.Get("/users/${user}/projects")
+func projectsCommand(client api.Client, cfg config.Config, quiet bool, format string, page int, out io.Writer) error {
+	path := "/users/${user}/projects"
+	if page > 0 {
+		path += fmt.Sprintf("?page=%d", page)
+	}
+
+	resp, status, err := client.Get(path)
 	if err != nil {
 		if status == 404 {
 			return fmt.Errorf("cannot list projects: User %s not found. Please check your configuration", cfg.Get("user"))
@@ -63,17 +68,19 @@ func projectsCommand(client api.Client, cfg config.Config, quiet bool, format st
 func NewCommand(client api.Client, cfg config.Config) *cobra.Command {
 	var quiet *bool
 	var format *string
+	var page *int
 
 	cmd := &cobra.Command{
 		Use:   "projects",
 		Short: "List all your projects",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return projectsCommand(client, cfg, *quiet, *format, os.Stdout)
+			return projectsCommand(client, cfg, *quiet, *format, *page, os.Stdout)
 		},
 	}
 
 	quiet = cmd.Flags().BoolP("quiet", "q", false, "Only display numeric IDs")
 	format = cmd.Flags().String("format", "", "Pretty-print projects using a Go template")
+	page = cmd.Flags().Int("page", 1, "Page of results to display")
 
 	return cmd
 }

--- a/cmd/projects/projects.go
+++ b/cmd/projects/projects.go
@@ -15,12 +15,8 @@ import (
 )
 
 func projectsCommand(client api.Client, cfg config.Config, quiet bool, format string, page int, out io.Writer) error {
-	path := "/users/${user}/projects"
-	if page > 0 {
-		path += fmt.Sprintf("?page=%d", page)
-	}
+	resp, status, err := client.Get(fmt.Sprintf("/users/${user}/projects?page=%d", page))
 
-	resp, status, err := client.Get(path)
 	if err != nil {
 		if status == 404 {
 			return fmt.Errorf("cannot list projects: User %s not found. Please check your configuration", cfg.Get("user"))

--- a/cmd/projects/projects_test.go
+++ b/cmd/projects/projects_test.go
@@ -16,7 +16,7 @@ func TestClientError(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", &out)
+	err := projectsCommand(client, config, true, "", 0, &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -38,7 +38,7 @@ func TestUnknownProject(t *testing.T) {
 		CacheData: &mock.Cache{},
 		Cfg:       map[string]string{"user": "Dilbert"},
 	}
-	err := projectsCommand(client, config, true, "", &out)
+	err := projectsCommand(client, config, true, "", 0, &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -58,7 +58,7 @@ func TestBrokenResponse(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", &out)
+	err := projectsCommand(client, config, true, "", 0, &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -74,7 +74,7 @@ func TestEmptyResult(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", &out)
+	err := projectsCommand(client, config, true, "", 0, &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -91,7 +91,7 @@ func TestQuietOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", &out)
+	err := projectsCommand(client, config, true, "", 0, &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -108,7 +108,7 @@ func TestFormattedOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "{{.Name}}", &out)
+	err := projectsCommand(client, config, false, "{{.Name}}", 0, &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -124,7 +124,7 @@ func TestFormattedOutputError(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "{{.Broken}", &out)
+	err := projectsCommand(client, config, false, "{{.Broken}", 0, &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -148,7 +148,7 @@ func TestTemplateExecutionError(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "{{.Name}}", &mockOutput{err: fmt.Errorf("some error")})
+	err := projectsCommand(client, config, false, "{{.Name}}", 0, &mockOutput{err: fmt.Errorf("some error")})
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -162,7 +162,7 @@ func TestTableOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "", &out)
+	err := projectsCommand(client, config, false, "", 0, &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -182,7 +182,7 @@ func TestEmptyTableOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "", &out)
+	err := projectsCommand(client, config, false, "", 0, &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -200,7 +200,7 @@ func TestCache(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &cache,
 	}
-	err := projectsCommand(client, config, true, "", &out)
+	err := projectsCommand(client, config, true, "", 0, &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}


### PR DESCRIPTION
Right now this just handles taking the flag value and setting the `page` query parameter to the API url. At this point I'm looking for feedback and feeling out the direction we want to go with this. 

The GitLab API does return a number of useful headers describing pagination state (next page, previous page, total records, etc.), but these are currently only available in `api.go`. I'm curious if you had anything in mind for how to get this info back to the commands themselves, since right now only the response body is getting sent back.