### PR TITLE
Add environment scope column to var command output

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,9 +49,10 @@ type PipelineDetails struct {
 }
 
 type Var struct {
-	Key       string
-	Value     string
-	Protected bool
+	Key         	 string
+	Value       	 string
+	Protected   	 bool
+	EnvironmentScope string `json:"environment_scope"`
 }
 
 func (pd PipelineDetails) Duration(now time.Time) string {

--- a/table/table.go
+++ b/table/table.go
@@ -107,6 +107,7 @@ func calcVarColumnWidths(vars []api.Var) map[string]int {
 	res["key"] = 20
 	res["value"] = 40
 	res["protected"] = 9
+	res["environment_scope"] = 11
 
 	for _, v := range vars {
 		w := len(v.Key)
@@ -117,6 +118,11 @@ func calcVarColumnWidths(vars []api.Var) map[string]int {
 		w = len(v.Value)
 		if w > res["value"] {
 			res["value"] = w
+		}
+
+		w = len(v.EnvironmentScope)
+		if w > res["environment_scope"] {
+			res["environment_scope"] = w
 		}
 	}
 	return res
@@ -178,15 +184,16 @@ func PrintIssues(out io.Writer, issues []api.Issue) {
 
 func PrintVars(out io.Writer, vars []api.Var) {
 	widths := calcVarColumnWidths(vars)
-	fmt.Fprintf(out, "%s %s %s\n",
+	fmt.Fprintf(out, "%s %s %s %s\n",
 		pad("KEY", widths["key"]),
 		pad("VALUE", widths["value"]),
-		pad("PROTECTED", widths["protected"]))
+		pad("PROTECTED", widths["protected"]),
+		pad("ENVIRONMENT", widths["environment_scope"]))
 	for _, v := range vars {
-		fmt.Fprintf(out, "%s %s %s\n",
+		fmt.Fprintf(out, "%s %s %s %s\n",
 			pad(v.Key, widths["key"]),
 			pad(v.Value, widths["value"]),
-			pad(fmt.Sprintf("%t", v.Protected), widths["protected"]))
-
+			pad(fmt.Sprintf("%t", v.Protected), widths["protected"]),
+			pad(v.EnvironmentScope, widths["environment_scope"]))
 	}
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -184,13 +184,13 @@ func TestVarsTable(t *testing.T) {
 			"empty input",
 			&strings.Builder{},
 			[]api.Var{},
-			"KEY                  VALUE                                    PROTECTED\n",
+			"KEY                  VALUE                                    PROTECTED ENVIRONMENT\n",
 		},
 		{
 			"nil input",
 			&strings.Builder{},
 			nil,
-			"KEY                  VALUE                                    PROTECTED\n",
+			"KEY                  VALUE                                    PROTECTED ENVIRONMENT\n",
 		},
 		{
 			"happy path",
@@ -200,28 +200,32 @@ func TestVarsTable(t *testing.T) {
 					Key:       "key 1",
 					Value:     "value 1",
 					Protected: false,
+					EnvironmentScope: "test",
 				},
 				{
 					Key:       "",
 					Value:     "",
 					Protected: true,
+					EnvironmentScope: "test",
 				},
 				{
 					Key:       "",
 					Value:     "some value",
 					Protected: false,
+					EnvironmentScope: "test",
 				},
 				{
 					Key:       "some key",
 					Value:     "",
 					Protected: false,
+					EnvironmentScope: "test",
 				},
 			},
-			`KEY                  VALUE                                    PROTECTED
-key 1                value 1                                  false    
-                                                              true     
-                     some value                               false    
-some key                                                      false    
+			`KEY                  VALUE                                    PROTECTED ENVIRONMENT
+key 1                value 1                                  false     test       
+                                                              true      test       
+                     some value                               false     test       
+some key                                                      false     test       
 `,
 		},
 	}
@@ -231,6 +235,7 @@ some key                                                      false
 			PrintVars(tt.writer, tt.vars)
 			if tt.writer.String() != tt.out {
 				t.Errorf("Unexpected result: '%s'", tt.writer.String())
+				t.Errorf("Expected result:   '%s'", tt.out)
 			}
 		})
 	}


### PR DESCRIPTION
The CI variables screen in the GitLab web UI is pretty terrible so this would be a welcome enhancement.