### PR TITLE
fix: don't print warning when config file doesn't exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,7 +99,9 @@ func checkPermissions(f *os.File) {
 func Read() Config {
 	f, err := os.Open(gitlabCLIConf())
 	if err != nil {
-		fmt.Printf("WARNING: Error opening configuration file: %s\n\n", err)
+		if !os.IsNotExist(err) {
+			fmt.Printf("WARNING: Error opening configuration file: %s\n\n", err)
+		}
 		return &defaultConfig
 	}
 	defer f.Close()


### PR DESCRIPTION
closes #26