### PR TITLE
feat: add 'GROUP' parameter to 'projects' cmd

### DIFF
--- a/cmd/projects/projects_test.go
+++ b/cmd/projects/projects_test.go
@@ -16,7 +16,7 @@ func TestClientError(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", 0, false, &out)
+	err := projectsCommand(client, config, true, "", 0, false, "", &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -38,7 +38,7 @@ func TestUnknownProject(t *testing.T) {
 		CacheData: &mock.Cache{},
 		Cfg:       map[string]string{"user": "Dilbert"},
 	}
-	err := projectsCommand(client, config, true, "", 0, false, &out)
+	err := projectsCommand(client, config, true, "", 0, false, "", &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -58,7 +58,7 @@ func TestBrokenResponse(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", 0, false, &out)
+	err := projectsCommand(client, config, true, "", 0, false, "", &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -74,7 +74,7 @@ func TestEmptyResult(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", 0, false, &out)
+	err := projectsCommand(client, config, true, "", 0, false, "", &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -91,7 +91,7 @@ func TestQuietOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, true, "", 0, false, &out)
+	err := projectsCommand(client, config, true, "", 0, false, "", &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -108,7 +108,7 @@ func TestFormattedOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "{{.Name}}", 0, false, &out)
+	err := projectsCommand(client, config, false, "{{.Name}}", 0, false, "", &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -124,7 +124,7 @@ func TestFormattedOutputError(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "{{.Broken}", 0, false, &out)
+	err := projectsCommand(client, config, false, "{{.Broken}", 0, false, "", &out)
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -148,7 +148,7 @@ func TestTemplateExecutionError(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "{{.Name}}", 0, false, &mockOutput{err: fmt.Errorf("some error")})
+	err := projectsCommand(client, config, false, "{{.Name}}", 0, false, "", &mockOutput{err: fmt.Errorf("some error")})
 	if err == nil {
 		t.Error("Expected a non-nil error")
 	}
@@ -162,7 +162,7 @@ func TestTableOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "", 0, false, &out)
+	err := projectsCommand(client, config, false, "", 0, false, "", &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -182,7 +182,7 @@ func TestEmptyTableOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, false, "", 0, false, &out)
+	err := projectsCommand(client, config, false, "", 0, false, "", &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -200,7 +200,7 @@ func TestCache(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &cache,
 	}
-	err := projectsCommand(client, config, true, "", 0, false, &out)
+	err := projectsCommand(client, config, true, "", 0, false, "", &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}


### PR DESCRIPTION
The `projects` command now has a parameter `GROUP`:

```
$ gitlab projects -h
List all your projects or projects within a specific group

Usage:
  gitlab projects [GROUP] [flags]

Flags:
      --format string   Pretty-print projects using a Go template
  -h, --help            help for projects
      --member          Displays projects you are a member of
      --page int        Page of results to display (default 1)
  -q, --quiet           Only display numeric IDs
```

@asitemade4u would sth. like that be what you were expecting?
closes #37