### PR TITLE
feat: refactor go-template output for the `get` command

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,76 +10,11 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/makkes/gitlab-cli/config"
 )
 
-type Project struct {
-	ID             int    `json:"id"`
-	Name           string `json:"name"`
-	SSHGitURL      string `json:"ssh_url_to_repo"`
-	HTTPGitURL     string `json:"http_url_to_repo"`
-	URL            string `json:"web_url"`
-	LastActivityAt string `json:"last_activity_at"`
-}
-
-type Issue struct {
-	ProjectID int    `json:"project_id"`
-	ID        int    `json:"iid"`
-	Title     string `json:"title"`
-	URL       string `json:"web_url"`
-	State     string `json:"state"`
-}
-
-type Pipeline struct {
-	ID     int
-	Status string
-}
-
-type PipelineDetails struct {
-	ProjectID        int
-	ID               int
-	Status           string
-	URL              string    `json:"web_url"`
-	RecordedDuration *int      `json:"duration"`
-	StartedAt        time.Time `json:"started_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
-	FinishedAt       time.Time `json:"finished_at"`
-}
-
-type Var struct {
-	Key              string
-	Value            string
-	Protected        bool
-	EnvironmentScope string `json:"environment_scope"`
-}
-
-func (pd PipelineDetails) Duration(now time.Time) string {
-	if pd.Status == "running" {
-		started := pd.StartedAt
-		if !pd.FinishedAt.IsZero() {
-			started = pd.UpdatedAt
-		}
-		return now.Sub(started).Truncate(time.Second).String()
-	}
-	if pd.RecordedDuration == nil {
-		return "-"
-	}
-	return time.Duration(int(time.Second) * *pd.RecordedDuration).String()
-}
-
-type Pipelines []Pipeline
-
-func (p Pipelines) Filter(cb func(int, Pipeline) bool) Pipelines {
-	res := make(Pipelines, 0)
-	for idx, pipeline := range p {
-		if cb(idx, pipeline) {
-			res = append(res, pipeline)
-		}
-	}
-	return res
-}
+var ErrNotLoggedIn = errors.New("You are not logged in")
 
 type Client interface {
 	Get(path string) ([]byte, int, error)
@@ -191,8 +126,6 @@ func (c HTTPClient) FindProject(nameOrID string) (*Project, error) {
 	}
 	return &project, nil
 }
-
-var ErrNotLoggedIn = errors.New("You are not logged in")
 
 func (c HTTPClient) isLoggedIn() bool {
 	return c.config != nil && c.config.Get(config.URL) != "" && c.config.Get(config.Token) != ""

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,69 @@
+package api
+
+import "time"
+
+type Project struct {
+	ID             int    `json:"id"`
+	Name           string `json:"name"`
+	SSHGitURL      string `json:"ssh_url_to_repo"`
+	HTTPGitURL     string `json:"http_url_to_repo"`
+	URL            string `json:"web_url"`
+	LastActivityAt string `json:"last_activity_at"`
+}
+
+type Issue struct {
+	ProjectID int    `json:"project_id"`
+	ID        int    `json:"iid"`
+	Title     string `json:"title"`
+	URL       string `json:"web_url"`
+	State     string `json:"state"`
+}
+
+type Pipeline struct {
+	ID     int
+	Status string
+}
+
+type PipelineDetails struct {
+	ProjectID        int
+	ID               int
+	Status           string
+	URL              string    `json:"web_url"`
+	RecordedDuration *int      `json:"duration"`
+	StartedAt        time.Time `json:"started_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	FinishedAt       time.Time `json:"finished_at"`
+}
+
+type Var struct {
+	Key              string
+	Value            string
+	Protected        bool
+	EnvironmentScope string `json:"environment_scope"`
+}
+
+func (pd PipelineDetails) Duration(now time.Time) string {
+	if pd.Status == "running" {
+		started := pd.StartedAt
+		if !pd.FinishedAt.IsZero() {
+			started = pd.UpdatedAt
+		}
+		return now.Sub(started).Truncate(time.Second).String()
+	}
+	if pd.RecordedDuration == nil {
+		return "-"
+	}
+	return time.Duration(int(time.Second) * *pd.RecordedDuration).String()
+}
+
+type Pipelines []Pipeline
+
+func (p Pipelines) Filter(cb func(int, Pipeline) bool) Pipelines {
+	res := make(Pipelines, 0)
+	for idx, pipeline := range p {
+		if cb(idx, pipeline) {
+			res = append(res, pipeline)
+		}
+	}
+	return res
+}

--- a/cmd/get/issues/issues.go
+++ b/cmd/get/issues/issues.go
@@ -34,10 +34,6 @@ func issuesCommand(scope string, format string, client api.Client, all bool, pag
 	if err != nil {
 		return err
 	}
-	issuesIf := make([]interface{}, len(issues))
-	for idx, i := range issues {
-		issuesIf[idx] = i
-	}
 
 	return output.Print(resp, format, out, func() error {
 		table.PrintIssues(out, issues)
@@ -47,7 +43,7 @@ func issuesCommand(scope string, format string, client api.Client, all bool, pag
 			fmt.Fprintf(out, "%s\n", issue.Title)
 		}
 		return nil
-	}, issuesIf)
+	}, issues)
 }
 
 func NewCommand(client api.Client, project *string, format *string) *cobra.Command {

--- a/cmd/get/output/output.go
+++ b/cmd/get/output/output.go
@@ -13,7 +13,7 @@ import (
 
 var ErrUnknownFormatRequested error = fmt.Errorf("unknown output format requested")
 
-func Print(b []byte, format string, out io.Writer, tableFunc func() error, nameFunc func() error, items []interface{}) error {
+func Print(b []byte, format string, out io.Writer, tableFunc func() error, nameFunc func() error, items interface{}) error {
 	switch {
 	case format == "json":
 		var buf bytes.Buffer
@@ -31,12 +31,9 @@ func Print(b []byte, format string, out io.Writer, tableFunc func() error, nameF
 		if err != nil {
 			return fmt.Errorf("template parsing error: %s", err)
 		}
-		for _, p := range items {
-			err = tmpl.Execute(out, p)
-			if err != nil {
-				return fmt.Errorf("template parsing error: %s", err)
-			}
-			fmt.Fprintln(out)
+		err = tmpl.Execute(out, items)
+		if err != nil {
+			return fmt.Errorf("template parsing error: %s", err)
 		}
 		return nil
 	default:

--- a/cmd/get/pipelines/pipelines.go
+++ b/cmd/get/pipelines/pipelines.go
@@ -83,11 +83,6 @@ func NewCommand(client api.Client, project *string, format *string) *cobra.Comma
 				return err
 			}
 
-			pdIfs := make([]interface{}, len(pds))
-			for idx, pd := range pds {
-				pdIfs[idx] = pd
-			}
-
 			return output.Print(resp, *format, os.Stdout, func() error {
 				table.PrintPipelines(pds)
 				return nil
@@ -96,7 +91,7 @@ func NewCommand(client api.Client, project *string, format *string) *cobra.Comma
 					fmt.Printf("%d:%d\n", p.ProjectID, p.ID)
 				}
 				return nil
-			}, pdIfs)
+			}, pds)
 		},
 	}
 

--- a/cmd/get/projects/projects.go
+++ b/cmd/get/projects/projects.go
@@ -41,27 +41,6 @@ func projectsCommand(client api.Client, cfg config.Config, format string, page i
 	}
 	cfg.Write()
 
-	// if format != "" {
-	// 	tmpl, err := template.New("").Parse(format)
-	// 	if err != nil {
-	// 		return fmt.Errorf("template parsing error: %s", err)
-	// 	}
-
-	// 	for _, p := range projects {
-	// 		err = tmpl.Execute(out, p)
-	// 		if err != nil {
-	// 			return fmt.Errorf("template parsing error: %s", err)
-	// 		}
-	// 		fmt.Fprintln(out)
-	// 	}
-	// 	return nil
-	// }
-
-	projectsIf := make([]interface{}, len(projects))
-	for idx, p := range projects {
-		projectsIf[idx] = p
-	}
-
 	return output.Print(resp, format, out, func() error {
 		table.PrintProjects(out, projects)
 		return nil
@@ -70,7 +49,7 @@ func projectsCommand(client api.Client, cfg config.Config, format string, page i
 			fmt.Fprintf(out, "%s\n", p.Name)
 		}
 		return nil
-	}, projectsIf)
+	}, projects)
 }
 
 func NewCommand(client api.Client, cfg config.Config, format *string) *cobra.Command {

--- a/cmd/get/projects/projects_test.go
+++ b/cmd/get/projects/projects_test.go
@@ -108,7 +108,7 @@ func TestFormattedOutput(t *testing.T) {
 	config := &mock.Config{
 		CacheData: &mock.Cache{},
 	}
-	err := projectsCommand(client, config, "go-template={{.Name}}", 0, false, &out)
+	err := projectsCommand(client, config, `go-template={{range .}}{{.Name}}{{"\n"}}{{end}}`, 0, false, &out)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}

--- a/cmd/get/vars/vars.go
+++ b/cmd/get/vars/vars.go
@@ -36,11 +36,6 @@ func NewCommand(client api.Client, project *string, format *string) *cobra.Comma
 				return fmt.Errorf("cannot list variables: %s", err)
 			}
 
-			varIfs := make([]interface{}, len(vars))
-			for idx, v := range vars {
-				varIfs[idx] = v
-			}
-
 			return output.Print(resp, *format, os.Stdout, func() error {
 				table.PrintVars(os.Stdout, vars)
 				return nil
@@ -49,7 +44,7 @@ func NewCommand(client api.Client, project *string, format *string) *cobra.Comma
 					fmt.Fprintf(os.Stdout, "%s\n", v.Key)
 				}
 				return nil
-			}, varIfs)
+			}, vars)
 		},
 	}
 }


### PR DESCRIPTION
This way, it's not necessary to create a slice of `interface{}`
objects, anymore in each `get` sub-command and helps us get rid of
lots of boilerplate code.

This changes the user experience in such a way that the template would
have to iterate over a slice now. So

```
gitlab -p p1 get pipelines -a -o go-template='{{.URL}}'
```
becomes
```
gitlab -p p1 get pipelines -a -o go-template='{{range .}}{{.URL}}{{"\n"}}{{end}}'
```
to achieve the same output.