### PR TITLE
feat: don't upgrade major version by default

### DIFF
--- a/cmd/update/releases_test.atom
+++ b/cmd/update/releases_test.atom
@@ -6,10 +6,10 @@
   <title>Release notes from gitlab-cli</title>
   <updated>2019-12-24T08:51:05Z</updated>
   <entry>
-    <id>tag:github.com,2008:Repository/168714048/v4.0.0-beta.1</id>
+    <id>tag:github.com,2008:Repository/168714048/v3.8.0-beta.1</id>
     <updated>2019-12-24T08:58:17Z</updated>
-    <link rel="alternate" type="text/html" href="https://github.com/makkes/gitlab-cli/releases/tag/v4.0.0-beta.1"/>
-    <title>v4.0.0-beta.1</title>
+    <link rel="alternate" type="text/html" href="https://github.com/makkes/gitlab-cli/releases/tag/v3.8.0-beta.1"/>
+    <title>v3.8.0-beta.1</title>
     <content type="html">Pre-release with great new stuff</content>
     <author>
       <name>makkes</name>

--- a/cmd/update/releases_test_major_upgrade.atom
+++ b/cmd/update/releases_test_major_upgrade.atom
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="en-US">
+  <id>tag:github.com,2008:https://github.com/makkes/gitlab-cli/releases</id>
+  <link type="text/html" rel="alternate" href="https://github.com/makkes/gitlab-cli/releases"/>
+  <link type="application/atom+xml" rel="self" href="https://github.com/makkes/gitlab-cli/releases.atom"/>
+  <title>Release notes from gitlab-cli</title>
+  <updated>2019-12-24T08:51:05Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Repository/168714048/v4.0.0</id>
+    <updated>2019-12-24T08:58:17Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/makkes/gitlab-cli/releases/tag/v4.0.0"/>
+    <title>v4.0.0</title>
+    <content type="html">New major version with great new stuff</content>
+    <author>
+      <name>makkes</name>
+    </author>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/387444?s=60&amp;v=4"/>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Repository/168714048/v3.6.3</id>
+    <updated>2019-12-23T08:58:17Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/makkes/gitlab-cli/releases/tag/v3.6.3"/>
+    <title>3.6.3</title>
+    <content type="html">&lt;h1&gt;Minor enhancements&lt;/h1&gt;
+&lt;ul&gt;
+&lt;li&gt;Add &#39;--dry-run&#39; flag to the &#39;update&#39; cmd&lt;/li&gt;
+&lt;/ul&gt;</content>
+    <author>
+      <name>makkes</name>
+    </author>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/387444?s=60&amp;v=4"/>
+  </entry>
+</feed>

--- a/cmd/update/releases_test_major_upgrade_pre.atom
+++ b/cmd/update/releases_test_major_upgrade_pre.atom
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="en-US">
+  <id>tag:github.com,2008:https://github.com/makkes/gitlab-cli/releases</id>
+  <link type="text/html" rel="alternate" href="https://github.com/makkes/gitlab-cli/releases"/>
+  <link type="application/atom+xml" rel="self" href="https://github.com/makkes/gitlab-cli/releases.atom"/>
+  <title>Release notes from gitlab-cli</title>
+  <updated>2019-12-24T08:51:05Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Repository/168714048/v4.0.0-beta.1</id>
+    <updated>2019-12-24T08:58:17Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/makkes/gitlab-cli/releases/tag/v4.0.0-beta.1"/>
+    <title>v4.0.0-beta.1</title>
+    <content type="html">New major version with great new stuff</content>
+    <author>
+      <name>makkes</name>
+    </author>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/387444?s=60&amp;v=4"/>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Repository/168714048/v3.6.3</id>
+    <updated>2019-12-23T08:58:17Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/makkes/gitlab-cli/releases/tag/v3.6.3"/>
+    <title>3.6.3</title>
+    <content type="html">&lt;h1&gt;Minor enhancements&lt;/h1&gt;
+&lt;ul&gt;
+&lt;li&gt;Add &#39;--dry-run&#39; flag to the &#39;update&#39; cmd&lt;/li&gt;
+&lt;/ul&gt;</content>
+    <author>
+      <name>makkes</name>
+    </author>
+    <media:thumbnail height="30" width="30" url="https://avatars0.githubusercontent.com/u/387444?s=60&amp;v=4"/>
+  </entry>
+</feed>

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -19,10 +19,12 @@ import (
 
 func TestUpdate(t *testing.T) {
 	tests := map[string]struct {
+		feed           string
 		currentVersion string
 		updatedVersion string
 		updatedBinary  []byte
 		dryRun         bool
+		upgradeMajor   bool
 		pre            bool
 		repo           string
 		out            *regexp.Regexp
@@ -53,33 +55,66 @@ func TestUpdate(t *testing.T) {
 			out:            regexp.MustCompile(`^A new version is available: v3.6.3\nSee http://127.0.0.1:\d+/releases/v3.6.3 for details\n`),
 		},
 		"unreachable repo": {
-			repo:          "http://doesntexist",
-			outErr:        true,
-			out:           regexp.MustCompile(`^Could not fetch latest version: `),
-			updatedBinary: []byte{},
+			repo:           "http://doesntexist",
+			currentVersion: "1.3.0",
+			outErr:         true,
+			out:            regexp.MustCompile(`^Could not fetch latest version: `),
+			updatedBinary:  []byte{},
 		},
 		"dry-run update to pre-release": {
 			currentVersion: "3.6.3",
-			updatedVersion: "4.0.0-beta.1",
+			updatedVersion: "3.8.0-beta.1",
 			updatedBinary:  []byte{},
 			dryRun:         true,
 			pre:            true,
-			out:            regexp.MustCompile(`^A new version is available: v4.0.0-beta.1\nSee http://127.0.0.1:\d+/releases/v4.0.0-beta.1 for details\n`),
+			out:            regexp.MustCompile(`^A new version is available: v3.8.0-beta.1\nSee http://127.0.0.1:\d+/releases/v3.8.0-beta.1 for details\n`),
 		},
 		"update to pre-release": {
 			currentVersion: "3.6.3",
-			updatedVersion: "4.0.0-beta.1",
+			updatedVersion: "3.8.0-beta.1",
 			updatedBinary:  []byte("the updated binary"),
 			dryRun:         false,
 			pre:            true,
+			out:            regexp.MustCompile(`^Updating to v3.8.0-beta.1\n`),
+		},
+		"no update of major version": {
+			feed:           "releases_test_major_upgrade.atom",
+			currentVersion: "3.6.3",
+			updatedVersion: "4.0.0",
+			updatedBinary:  []byte{},
+			dryRun:         false,
+			pre:            false,
+			out:            regexp.MustCompile(`^You're already on the latest version `),
+		},
+		"update of major version": {
+			feed:           "releases_test_major_upgrade.atom",
+			currentVersion: "3.6.3",
+			updatedVersion: "4.0.0",
+			updatedBinary:  []byte("4.0.0"),
+			dryRun:         false,
+			pre:            false,
+			upgradeMajor:   true,
+			out:            regexp.MustCompile(`^Updating to v4.0.0\n`),
+		},
+		"update of major pre-release version": {
+			feed:           "releases_test_major_upgrade_pre.atom",
+			currentVersion: "3.6.3",
+			updatedVersion: "4.0.0-beta.1",
+			updatedBinary:  []byte("4.0.0 Beta.1"),
+			dryRun:         false,
+			pre:            true,
+			upgradeMajor:   true,
 			out:            regexp.MustCompile(`^Updating to v4.0.0-beta.1\n`),
 		},
-
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(tt *testing.T) {
-			releasesFeed, err := ioutil.ReadFile("releases_test.atom")
+			feed := "releases_test.atom"
+			if tc.feed != "" {
+				feed = tc.feed
+			}
+			releasesFeed, err := ioutil.ReadFile(feed)
 			require.NoError(t, err)
 
 			outFile, err := ioutil.TempFile("", "gitlab-update-test")
@@ -105,7 +140,7 @@ func TestUpdate(t *testing.T) {
 			config.Version = tc.currentVersion
 			var out strings.Builder
 
-			err = updateCommand(tc.dryRun, tc.pre, &out, func() (string, error) { return outFile.Name(), nil })
+			err = updateCommand(tc.dryRun, tc.pre, tc.upgradeMajor, &out, func() (string, error) { return outFile.Name(), nil })
 
 			if tc.outErr {
 				require.Error(t, err)

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
-func LatestVersion(repo string, includePreReleases bool) (string, error) {
+func LatestVersion(repo string, currentVersion semver.Version, upgradeMajor, includePreReleases bool) (string, error) {
 	fp := gofeed.NewParser()
 	feed, err := fp.ParseURL(repo + "/releases.atom")
 	if err != nil {
@@ -30,6 +30,9 @@ func LatestVersion(repo string, includePreReleases bool) (string, error) {
 		}
 		if v.Pre != nil && !includePreReleases {
 			continue // this is a pre-release, skip it
+		}
+		if v.Major > currentVersion.Major && !upgradeMajor {
+			continue // this is a new major version, skip ip
 		}
 		return fmt.Sprintf("v%s", v.String()), nil
 	}


### PR DESCRIPTION
Forcing major upgrade can be done by providing the `--major` flag.

Closes #63