### PR TITLE
[backport 3.x] feat: add `--pre` flag to `update` command (#65)

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -77,17 +77,19 @@ func updateCommand(dryRun bool, includePreReleases bool, upgradeMajor bool, out 
 func NewCommand() *cobra.Command {
 	var dryRun *bool
 	var upgradeMajor *bool
+	var includePre *bool
 
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update GitLab CLI to latest version",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return updateCommand(*dryRun, false, *upgradeMajor, os.Stdout, os.Executable)
+			return updateCommand(*dryRun, *includePre, *upgradeMajor, os.Stdout, os.Executable)
 		},
 	}
 
 	dryRun = cmd.Flags().BoolP("dry-run", "d", false, "Only check if an update is available")
+	includePre = cmd.Flags().BoolP("pre", "", false, "Upgrade to next pre-release version, if available")
 	upgradeMajor = cmd.Flags().BoolP("major", "", false, "Upgrade major version, if available")
 
 	return cmd


### PR DESCRIPTION
This is a backport of #65.

With this flag, users can now choose to upgrade to the next
pre-release version if there is one available.

Example:

You're running gitlab 3.7.2 at the moment and 3.8.0-beta.1 is released
which is a pre-release version. Running `gitlab update` will not
update to that beta version by default. If you run `gitlab update
--pre`, however, you will get that version installed.