### PR TITLE
Remove "Bash completion" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,6 @@ Currently GitLab CLI supports these commands:
 * `issue`: Manage issues
 * `status`: Display the current configuration of GitLab CLI
 
-## Bash Completion
-
-You can get your Bash to complete GitLab CLI commands very easily: Just type the
-following line in your shell:
-
-```sh
-. <(gitlab completion)
-```
-
-To have completion set up for you automatically just copy and paste the line
-from above into your `~/.bashrc` or `~/.profile`.
-
 ## License
 
 This software is distributed under the BSD 2-Clause License, see


### PR DESCRIPTION
I just installed the latest version of gitlab-cli. 

Apparently it doesn't have the "gitlab completion" command:

```
[:~] $ curl -sSfL https://raw.githubusercontent.com/makkes/gitlab-cli/master/install.sh | sh -s -- -b ~/bin
Downloading gitlab v3.7.3...
######################################################################## 100.0%#=#=-#  #
######################################################################## 100.0%
Installed gitlab v3.7.3 into /home/atsaloli/bin
[:~] $ . <(gitlab completion)
usage: gitlab [-h] [--version] [-v] [-d] [-c CONFIG_FILE] [-g GITLAB]
              [-o {json,legacy,yaml}] [-f FIELDS]
              {application-settings,audit-event,broadcast-message,current-user,current-user-email,current-user-gp-gkey,current-user-key,current-user-status,deploy-key,dockerfile,event,feature,geo-node,
```