### PR TITLE
build: move to GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,23 +10,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        with:
+          fetch-depth: 0
+      - name: Install asdf and tools
+        uses: asdf-vm/actions/install@v1
+      - name: create release
+        run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: |
-            TBD
-          draft: false
-          prerelease: false
-      - name: Generate artifacts
-        uses: skx/github-action-build@5ca2e55b7ba4583d27b0e4c256685dd7fffb4acf
-      - name: Upload artifacts
-        uses: alexellis/upload-assets@0.2.3
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_paths: '["./build/gitlab_*"]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test Go ${{ matrix.go }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
-      with:
-          go-version: ${{ matrix.go }}
-    - name: Get golangci-lint on Windows
-      if: runner.os == 'Windows'
-      shell: bash
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.43.0
-    - name: Get golangci-lint on macOS and Linux
-      if: runner.os == 'macOS' || runner.os == 'Linux'
-      shell: bash
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.43.0
+    - uses: actions/checkout@v2
+    - uses: asdf-vm/actions/install@v1
     - name: Lint code
-      if: runner.os == 'macOS' || runner.os == 'Linux'
+      if: runner.os == 'Linux'
       run: make lint
+    - name: pre-commit
+      uses: pre-commit/action@v2.0.3
+      if: runner.os == 'Linux'
+      with:
+        extra_args: --all-files
+      env:
+        SKIP: no-commit-to-branch,golangci-lint
     - name: Run unit tests
       run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,21 +2,14 @@ name: Test
 on: [push]
 jobs:
   test:
-    strategy:
-        matrix:
-            go: ['1.x']
-            os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    name: Test Go ${{ matrix.go }} on ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: asdf-vm/actions/install@v1
     - name: Lint code
-      if: runner.os == 'Linux'
       run: make lint
     - name: pre-commit
       uses: pre-commit/action@v2.0.3
-      if: runner.os == 'Linux'
       with:
         extra_args: --all-files
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /gitlab_v*
 cover.out
 /build
+
+# output of goreleaser
+/dist/

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,21 @@
+# `gitlint` is used to validate commit messages via `pre-commit` hook, enabled
+# via `pre-commit install -t commit-msg`.
+#
+# The format of this file is detailed at https://jorisroovers.com/gitlint/#configuration.
+
+[general]
+# Validate the commit title conforms to conventional commits (https://www.conventionalcommits.org/en/v1.0.0/).
+contrib=contrib-title-conventional-commits
+# Do not require a body in the git commit.
+ignore=body-is-missing
+
+[body-max-line-length]
+line-length=120
+
+[ignore-body-lines]
+# Ignore dependabot long lines.
+regex=^Bumps .+ from .+ to .+\.$
+
+[contrib-title-conventional-commits]
+# Specify allowed commit types. For details see: https://www.conventionalcommits.org/
+types = fix,feat,docs,style,refactor,perf,test,revert,ci,build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,56 @@
+project_name: gitlab
+
+changelog:
+  use: github
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+      - '^build:'
+
+release:
+  footer: |
+    ### Summary
+    **Full Changelog**: https://github.com/makkes/gitlab-cli/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+builds:
+  - id: gitlab
+    main: ./cmd/gitlab
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+      - -X 'github.com/makkes/gitlab-cli/config.Version={{ .Version }}'
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: '{{ .CommitTimestamp }}'
+universal_binaries:
+  - replace: true
+    id: gitlab
+archives:
+  - name_template: '{{ .ProjectName }}_v{{trimprefix .Version "v"}}_{{ .Os }}_{{ .Arch }}'
+  # This is a hack documented in https://github.com/goreleaser/goreleaser/blob/df0216d5855e9283d2106fb5acdb0e7b528a56e8/www/docs/customization/archive.md#packaging-only-the-binaries
+    files:
+      - none*
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incminor .Tag }}-dev"

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,9 @@
+{
+  "default": true,
+  "MD003": { "style": "atx" },
+  "MD004": { "style": "dash" },
+  "MD007": { "indent": 4 },
+  "MD013": false,
+  "MD030": { "ul_multi": 3, "ol_multi": 2 },
+  "MD035": { "style": "---" }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
   hooks:
   - id: trailing-whitespace
     stages: [commit]
+    exclude: "^(cmd\/get\/projects\/projects_test|table\/table_test)\\.go$"
   - id: check-yaml
     args: ["-m", "--unsafe"]
     stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   - id: go-mod-tidy
     name: go mod tidy
     entry: make mod-tidy
-    files: "(.*\\.go$|go.mod|go.sum)"
+    files: "(.*\\.go|go.mod|go.sum)$"
     language: system
     stages: [commit]
     pass_filenames: false
@@ -12,10 +12,10 @@ repos:
     name: golangci-lint
     entry: make lint
     language: system
-    files: "(.*\\.go$|go.mod|go.sum)"
+    files: "(.*\\.go|go.mod|go.sum)$"
     pass_filenames: false
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: trailing-whitespace
     stages: [commit]
@@ -55,7 +55,7 @@ repos:
   - id: script-must-have-extension
     stages: [commit]
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.8.0.1
+  rev: v0.8.0.3
   hooks:
   - id: shellcheck
     stages: [commit]

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ golangci-lint 1.44.2
 golang 1.17.7
 goreleaser 1.5.0
 pre-commit 2.17.0
+shfmt 3.4.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+golangci-lint 1.44.2
+golang 1.17.7
+goreleaser 1.5.0
+pre-commit 2.17.0

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ GitLab repos.
 
 The easiest installation method is to use the installation script:
 
-```
+```sh
 # install latest version into /usr/local/bin/
-curl -sSfL https://raw.githubusercontent.com/makkes/gitlab-cli/master/install.sh | sh -s 
+curl -sSfL https://raw.githubusercontent.com/makkes/gitlab-cli/master/install.sh | sh -s
 
 # install latest version into ~/bin/
 curl -sSfL https://raw.githubusercontent.com/makkes/gitlab-cli/master/install.sh | sh -s -- -b ~/bin
@@ -25,7 +25,7 @@ curl -sSfL https://raw.githubusercontent.com/makkes/gitlab-cli/master/install.sh
 If that script doesn't work for you and you have a Go environment set up you can
 use this command:
 
-```
+```sh
 go get github.com/makkes/gitlab-cli
 ```
 
@@ -34,9 +34,9 @@ release](https://github.com/makkes/gitlab-cli/releases).
 
 All commands of gitlab-cli currently require that you are authenticated. To do
 so you issue `gitlab login YOUR_TOKEN`. You obtain a personal access token
-at https://gitlab.com/profile/personal_access_tokens. To make use of all of
-gitlab-cli's features you need to grant api, read_user, read_repository and
-read_registry scopes.
+on your [settings page](https://gitlab.com/-/profile/personal_access_tokens).
+To make use of all of gitlab-cli's features you need to grant api, read_user,
+read_repository and read_registry scopes.
 
 ## Updating the CLI
 
@@ -44,23 +44,28 @@ Since version 3.6 the CLI has an `update` command that you can use to update the
 CLI's version so you don't have to download the latest release every time.
 
 Running
-```
+
+```sh
 gitlab update
 ```
+
 will update your version to the latest stable release of the current **major** release, so it would update from e.g. 3.7.1 to 3.8.0 but not to 4.0.0. If you'd like to upgrade to the next major release, provide the `--major` flag (available since 3.7.2):
-```
+
+```sh
 gitlab update --major
 ```
 
 ### Dry-run and pre-release updates
 
 If you would like to just check for availability of a new version, use the `--dry-run` flag:
-```
+
+```sh
 gitlab update --dry-run
 ```
 
 For the brave companions, there's also the `--pre` flag (available since 3.7.3) which will update to the next pre-release (i.e. alpha, beta or release candidate) version:
-```
+
+```sh
 gitlab update --pre
 ```
 
@@ -74,6 +79,7 @@ Currently GitLab CLI supports these commands:
 - `get`         Display one or more objects
 - `help`        Help about any command
 - `inspect`     Show details of a specific object
+<!-- markdownlint-disable-next-line MD034 -->
 - `login`       Login to GitLab. If URL is omitted then https://gitlab.com is used.
 - `status`      Display the current configuration of GitLab CLI
 - `update`      Update GitLab CLI to latest version
@@ -104,4 +110,3 @@ gitlab completion zsh |sudo tee "${fpath[1]}/_gitlab"
 
 This software is distributed under the BSD 2-Clause License, see
 [LICENSE](LICENSE) for more information.
-

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -12,11 +12,11 @@ func NewCommand(rootCmd *cobra.Command) *cobra.Command {
 		Use:   "completion",
 		Short: "Generate shell completion scripts",
 		Long: `Generate shell completion scripts
-		
+
 To load completions in the current shell run
 
 source <(gitlab completion SHELL)
-		
+
 To configure your bash shell to load completions for each session add the
 following line to your ~/.bashrc or ~/.profile:
 

--- a/install.sh
+++ b/install.sh
@@ -1,83 +1,85 @@
 #!/usr/bin/env sh
 
 is_command() {
-    command -v "$1" > /dev/null
+  command -v "$1" >/dev/null
 }
 
 echoerr() {
-    >&2 echo "$@"
+  echo >&2 "$@"
 }
 
 check_prereqs() {
-    if ! is_command curl; then
-        echoerr "curl is needed for this script to work"
-        exit 1
-    fi
-    if ! is_command grep; then
-        echoerr "grep is needed for this script to work"
-        exit 1
-    fi
-    if ! is_command cut; then
-        echoerr "cut is needed for this script to work"
-        exit 1
-    fi
-    if ! is_command sed; then
-        echoerr "sed is needed for this script to work"
-        exit 1
-    fi
+  if ! is_command curl; then
+    echoerr "curl is needed for this script to work"
+    exit 1
+  fi
+  if ! is_command grep; then
+    echoerr "grep is needed for this script to work"
+    exit 1
+  fi
+  if ! is_command cut; then
+    echoerr "cut is needed for this script to work"
+    exit 1
+  fi
+  if ! is_command sed; then
+    echoerr "sed is needed for this script to work"
+    exit 1
+  fi
 }
 
 do_install() {
-    set -e
-    check_prereqs
-    target_dir="/usr/local/bin"
-    while getopts "b:" arg; do
-        case "$arg" in
-          b)
-              target_dir="$OPTARG"
-              ;;
-          *)
-              exit 1
-              ;;
-        esac
-    done
-    shift $((OPTIND - 1))
-
-    version=${1:-}
-    [ -z "$version" ] && version="latest"
-
-    set +e
-    release_json=$(curl -fsLH 'Accept: application/json' https://github.com/makkes/gitlab-cli/releases/${version})
-    set -e
-    [ -z "$release_json" ] && echoerr "Unknown version ${version}" && exit 1
-    release_tag=$(echo "$release_json"|grep -o '"tag_name":"[^"]*"'|cut -d":" -f2|sed s/\"//g)
-
-    kernel_name=$(uname -s)
-    machine=$(uname -m)
-    case "${kernel_name}" in
-        Darwin)
-            os="darwin"
-            ;;
-        Linux)
-            os="linux"
-            ;;
-        *)
-            echoerr "Unsupported OS ${kernel_name}" && exit 1
-            ;;
+  set -e
+  check_prereqs
+  target_dir="/usr/local/bin"
+  while getopts "b:" arg; do
+    case "$arg" in
+    b)
+      target_dir="$OPTARG"
+      ;;
+    *)
+      exit 1
+      ;;
     esac
-    [ "${machine}" != "x86_64" ] && echoerr "Unsupported CPU architecture ${machine}" && exit 1
-    arch="amd64"
+  done
+  shift $((OPTIND - 1))
 
-    download_url="https://github.com/makkes/gitlab-cli/releases/download/${release_tag}/gitlab_${release_tag}_${os}_${arch}"
-    tmpdir=$(mktemp -d)
-    echo "Downloading gitlab ${release_tag}..."
-    set +e
-    curl --progress-bar -fLo "${tmpdir}"/gitlab "${download_url}"
-    [ "$?" != "0" ] && echoerr "Error downloading from ${download_url}" && exit 1
-    set -e
-    install "${tmpdir}/gitlab" "${target_dir}"
+  version=${1:-}
+  [ -z "$version" ] && version="latest"
 
-    echo "Installed gitlab ${release_tag} into ${target_dir}"
+  set +e
+  release_json=$(curl -fsLH 'Accept: application/json' https://github.com/makkes/gitlab-cli/releases/${version})
+  set -e
+  [ -z "$release_json" ] && echoerr "Unknown version ${version}" && exit 1
+  release_tag=$(echo "$release_json" | grep -o '"tag_name":"[^"]*"' | cut -d":" -f2 | sed s/\"//g)
+
+  kernel_name=$(uname -s)
+  machine=$(uname -m)
+  case "${kernel_name}" in
+  Darwin)
+    os="darwin"
+    ;;
+  Linux)
+    os="linux"
+    ;;
+  *)
+    echoerr "Unsupported OS ${kernel_name}" && exit 1
+    ;;
+  esac
+  [ "${machine}" != "x86_64" ] && echoerr "Unsupported CPU architecture ${machine}" && exit 1
+  arch="amd64"
+
+  download_url="https://github.com/makkes/gitlab-cli/releases/download/${release_tag}/gitlab_${release_tag}_${os}_${arch}"
+  tmpdir=$(mktemp -d)
+  echo "Downloading gitlab ${release_tag}..."
+  set +e
+  if ! curl --progress-bar -fLo "${tmpdir}"/gitlab "${download_url}"; then
+    echoerr "Error downloading from ${download_url}"
+    exit 1
+  fi
+  set -e
+  install "${tmpdir}/gitlab" "${target_dir}"
+
+  echo "Installed gitlab ${release_tag} into ${target_dir}"
 }
 
-(do_install $@)
+(do_install "$@")


### PR DESCRIPTION
This transition puts much of the burden of maintaining the build
process onto this external tool that has proven to "just work".

refs #79